### PR TITLE
Preinstall Python dev packages

### DIFF
--- a/get-python.sh
+++ b/get-python.sh
@@ -31,6 +31,8 @@ case ${OSNAME} in
             "libssl1.0.0"
             "libexpat1"
             "libffi6"
+            "python-dev"
+            "python3-dev"
         )
 
         BUILD_REQUIREMENTS=(
@@ -54,6 +56,8 @@ case ${OSNAME} in
             "expat"
             "libffi"
             "python-pip"
+            "python-devel"
+            "python3-devel"
         )
 
         BUILD_REQUIREMENTS=(


### PR DESCRIPTION
As some Python packages require compilation with Python headers, `python-dev` 
packages are now baked into the testing image.