### PR TITLE
Fix system upgrade for CentOS

### DIFF
--- a/get-python.sh
+++ b/get-python.sh
@@ -107,7 +107,7 @@ case ${OSNAME} in
         apt-get -y install "${@}"
         ;;
     "centos")
-        yum update
+        yum upgrade -y
         yum -y install epel-release
         yum -y groupinstall development
         yum -y install "${@}"


### PR DESCRIPTION
1. Replace `update` with `upgrade`.

CentOS `yum` behaves different compared to Debian's `apt` — it updates repository index upon every execution. Difference between `yum update` and `yum upgrade` is that `upgrade` will also remove obsolete packages.

2. Make `yum upgrade` non-interactive.

Due to the above, `yum upgrade` by default also works in interactive mode, asking the user if he/she want to update the packages. So add `-y` for non-interactive confirmation.