### PR TITLE
Pass on --enable-shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ provided Dockerfiles.
 To build Pythonista Docker image (by default based on **Debian**):
 
 ```
-docker build -t pythonista-deb
+docker build -t pythonista-deb .
 ```
 
 To build Pythonista Docker image based on **CentOS** use `Dockerfile.centos`:
 
 ```
-docker build -f Dockerfile.centos -t pythonista-yum
+docker build -f Dockerfile.centos -t pythonista-yum .
 ```
 
 Feedback

--- a/get-python.sh
+++ b/get-python.sh
@@ -130,7 +130,7 @@ function install_pyenv {
 #
 function install_python {
     echo "export PATH=\"\$PATH:/opt/python/$1/bin/\"" >> /etc/profile.d/pythonista.sh
-    CFLAGS="-g -O2" python-build "$1" "/opt/python/$1"
+    PYTHON_CONFIGURE_OPTS="--enable-shared" CFLAGS="-g -O2" python-build "$1" "/opt/python/$1"
 }
 
 #


### PR DESCRIPTION
I use Cython quite extensively. I found it neccessary to build shared libraries for the Python versions.
Would this be of interest for people in general?